### PR TITLE
Topological Sort and Back Propagation 

### DIFF
--- a/src/autodiff.ts
+++ b/src/autodiff.ts
@@ -1,3 +1,5 @@
+import { Scalar } from "./scalar.js";
+
 export function centralDifference(
     f: (...args: number[]) => number,
     vals: number[],
@@ -23,4 +25,20 @@ export class Context {
     get savedValues(): number[] {
         return this._savedValues;
     }
+}
+
+export function topologicalSort(scalar: Scalar): Scalar[] {
+    const visited = new Set<Scalar>();
+    const sorted = new Array<Scalar>();
+
+    const dfs: (scalar: Scalar) => void = (scalar) => {
+        if (visited.has(scalar)) return;
+        visited.add(scalar);
+        for (const parent of scalar.parents) {
+            dfs(parent);
+        }
+        sorted.push(scalar);
+    };
+    dfs(scalar);
+    return sorted.reverse();
 }

--- a/src/autodiff.ts
+++ b/src/autodiff.ts
@@ -42,3 +42,23 @@ export function topologicalSort(scalar: Scalar): Scalar[] {
     dfs(scalar);
     return sorted.reverse();
 }
+
+export function backPropagate(scalar: Scalar, dOut: number): void {
+    const sorted = topologicalSort(scalar);
+    const derivatives: Map<Scalar, number> = new Map();
+
+    derivatives.set(scalar, dOut);
+
+    for (const node of sorted) {
+        const d = derivatives.get(node);
+        if (d === undefined) continue;
+
+        if (node.isLeaf()) {
+            node.accumulateDerivative(d);
+        } else {
+            for (const [parent, grad] of node.chainRule(d)) {
+                derivatives.set(parent, (derivatives.get(parent) ?? 0) + grad);
+            }
+        }
+    }
+}

--- a/src/scalar.ts
+++ b/src/scalar.ts
@@ -139,6 +139,28 @@ export class Scalar {
         const inputs = h.inputs as Scalar[];
         return zip(inputs, gradients);
     }
+
+    isLeaf(): boolean {
+        return !this.history?.lastFn;
+    }
+
+    isConstant(): boolean {
+        return !this.history;
+    }
+
+    get parents(): Scalar[] {
+        return this.history?.inputs ?? [];
+    }
+
+    accumulateDerivative(d: number): void {
+        if (!this.isLeaf()) {
+            throw new Error("Cannot accumulate derivative of a non-leaf scalar");
+        }
+        if (this.derivative === null) {
+            this.derivative = 0;
+        }
+        this.derivative += d;
+    }
 }
 
 export { ScalarHistory };

--- a/src/scalar_functions.ts
+++ b/src/scalar_functions.ts
@@ -23,12 +23,20 @@ export abstract class ScalarFunction {
     static forward(ctx: Context, ...inputs: number[]): number {
         throw new Error("forward not implemented");
     }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        throw new Error("backward not implemented");
+    }
 }
 
 export class Add extends ScalarFunction {
     static forward(ctx: Context, a: number, b: number): number {
         // Don't need to save for backward since df/da = 1 and df/db = 1
         return operators.add(a, b);
+    }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        return [dOut, dOut];
     }
 }
 
@@ -37,12 +45,22 @@ export class Log extends ScalarFunction {
         ctx.saveForBackward(a);
         return operators.log(a);
     }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [a] = ctx.savedValues;
+        return [dOut * (1 / a!)];
+    }
 }
 
 export class Mul extends ScalarFunction {
     static forward(ctx: Context, a: number, b: number): number {
         ctx.saveForBackward(a, b);
         return operators.mul(a, b);
+    }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [a, b] = ctx.savedValues;
+        return [dOut * b!, dOut * a!];
     }
 }
 
@@ -51,11 +69,20 @@ export class Inv extends ScalarFunction {
         ctx.saveForBackward(a);
         return operators.inv(a);
     }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [a] = ctx.savedValues;
+        return [dOut * (-1 / a! ** 2)];
+    }
 }
 
 export class Neg extends ScalarFunction {
     static forward(ctx: Context, a: number): number {
         return operators.neg(a);
+    }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        return [dOut * (-1)];
     }
 }
 
@@ -65,12 +92,22 @@ export class Sigmoid extends ScalarFunction {
         ctx.saveForBackward(result);
         return result;
     }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [result] = ctx.savedValues;
+        return [dOut * result! * (1 - result!)];
+    }
 }
 
 export class Relu extends ScalarFunction {
     static forward(ctx: Context, a: number): number {
         ctx.saveForBackward(a);
         return operators.relu(a);
+    }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [a] = ctx.savedValues;
+        return [dOut * (a! > 0 ? 1 : 0)];
     }
 }
 
@@ -80,16 +117,29 @@ export class Exp extends ScalarFunction {
         ctx.saveForBackward(result);
         return result;
     }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [result] = ctx.savedValues;
+        return [dOut * result!];
+    }
 }
 
 export class LT extends ScalarFunction {
     static forward(ctx: Context, a: number, b: number): number {
         return operators.lt(a, b);
     }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        return [0, 0];
+    }
 }
 
 export class EQ extends ScalarFunction {
     static forward(ctx: Context, a: number, b: number): number {
         return operators.eq(a, b);
+    }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        return [0, 0];
     }
 }


### PR DESCRIPTION
Implemented helper functions in scalar to accumulate a derivative at a leaf node, to check if a scalar is a leaf node, and to get the parents of a node (inputs).

Also implemented topological sort using postorder DFS.

Used topological sort to implement back propagation to calculate derivatives of leaf nodes (inputs) and determine how they affect loss (output).