### PR TITLE
[don't merge yet] Scalar training: Spiral dataset optimizations

### DIFF
--- a/packages/demo/runScalar.ts
+++ b/packages/demo/runScalar.ts
@@ -47,8 +47,10 @@ class Linear extends Module {
     this.inSize = inSize;
     this.outSize = outSize;
 
+    const scale = Math.sqrt(2 / inSize);
+
     this.weights = Array.from({ length: outSize }, () =>
-      Array.from({ length: inSize }, () => new Parameter(new Scalar(2 * (Math.random() - 0.5))))
+      Array.from({ length: inSize }, () => new Parameter(new Scalar((Math.random() - 0.5) * 2 * scale)))
     );
 
     this.bias = Array.from({ length: outSize }, () => new Parameter(new Scalar(2 * (Math.random() - 0.5))));

--- a/packages/demo/runScalar.ts
+++ b/packages/demo/runScalar.ts
@@ -53,7 +53,7 @@ class Linear extends Module {
       Array.from({ length: inSize }, () => new Parameter(new Scalar((Math.random() - 0.5) * 2 * scale)))
     );
 
-    this.bias = Array.from({ length: outSize }, () => new Parameter(new Scalar(2 * (Math.random() - 0.5))));
+    this.bias = Array.from({ length: outSize }, () => new Parameter(new Scalar(0)));
 
     // register weights and bias as parameters in module
     // note that using our proxy autoregisters but not if it's in an array

--- a/packages/demo/runScalar.ts
+++ b/packages/demo/runScalar.ts
@@ -25,7 +25,7 @@ class Network extends Module<Parameter<Scalar>> {
     const outputs1: Scalar[] = this.layer1.forward(x);
 
     for (let i = 0; i < this.layer1.outSize; ++i) {
-      relu1.push(outputs1[i].relu());
+      relu1.push(outputs1[i].leakyRelu());
     }
 
     // return Scalar array of len 1

--- a/packages/tstorch/src/optimizer.ts
+++ b/packages/tstorch/src/optimizer.ts
@@ -10,6 +10,24 @@ export class Optimizer {
     constructor(parameters: Parameter<ParameterValue>[]) {
         this.parameters = parameters;
     }
+
+    zeroGrad() {
+        for (let p of this.parameters) {
+            if (!p.value || typeof p.value !== 'object') {
+                continue;
+            }
+            if ("derivative" in p.value) {
+                if (p.value.derivative !== null && p.value.derivative !== undefined) {
+                    p.value.derivative = 0;
+                }
+            }
+            if ("grad" in p.value) {
+                if (p.value.grad !== null && p.value.grad !== undefined) {
+                    p.value.grad = null;
+                }
+            }
+        }
+    }
 }
 
 export class SGD extends Optimizer {
@@ -20,35 +38,63 @@ export class SGD extends Optimizer {
         this.lr = lr;
     }
 
-    zeroGrad() {
+    step() {
         for (let p of this.parameters) {
-            if (!p.value || typeof p.value !== 'object') {
-                continue;
+            if (!p.value || typeof p.value !== 'object') continue;
+            if (p.value instanceof Scalar) {
+                const grad = p.value.derivative ?? 0;
+                p.value.data -= this.lr * grad;
             }
-            if ("derivative" in p.value) { 
-                if (p.value.derivative !== null && p.value.derivative !== undefined) {
-                    p.value.derivative = 0;
-                }
-            }
-            if ("grad" in p.value) { 
-                if (p.value.grad !== null && p.value.grad !== undefined) {
-                    p.value.grad = null;
-                }
-            }
+        }
+    }
+}
+
+export class Adam extends Optimizer {
+    lr: number;
+    beta1: number;
+    beta2: number;
+    eps: number;
+    t: number = 0;
+    private m: Map<Parameter<ParameterValue>, number> = new Map();
+    private v: Map<Parameter<ParameterValue>, number> = new Map();
+
+    constructor(
+        parameters: Parameter<Scalar>[],
+        lr: number = 0.001,
+        beta1: number = 0.9,
+        beta2: number = 0.999,
+        eps: number = 1e-8
+    ) {
+        super(parameters);
+        this.lr = lr;
+        this.beta1 = beta1;
+        this.beta2 = beta2;
+        this.eps = eps;
+        for (const p of parameters) {
+            this.m.set(p, 0);
+            this.v.set(p, 0);
         }
     }
 
     step() {
-        for (let p of this.parameters) {
-            if (!p.value || typeof p.value !== 'object') {
-                continue;
-            }
-
-        // Check for derivative (Scalar-like objects)
-        if (p.value instanceof Scalar) {
+        this.t++;
+        for (const p of this.parameters) {
+            if (!(p.value instanceof Scalar)) continue;
             const grad = p.value.derivative ?? 0;
-            p.value.data -= this.lr * grad;
+
+            let mi = this.m.get(p)!;
+            let vi = this.v.get(p)!;
+
+            mi = this.beta1 * mi + (1 - this.beta1) * grad;
+            vi = this.beta2 * vi + (1 - this.beta2) * grad * grad;
+
+            this.m.set(p, mi);
+            this.v.set(p, vi);
+
+            const mHat = mi / (1 - Math.pow(this.beta1, this.t));
+            const vHat = vi / (1 - Math.pow(this.beta2, this.t));
+
+            p.value.data -= this.lr * mHat / (Math.sqrt(vHat) + this.eps);
         }
     }
-}
 }

--- a/packages/tstorch/src/scalar.ts
+++ b/packages/tstorch/src/scalar.ts
@@ -10,6 +10,7 @@ import {
     Neg,
     Sigmoid,
     Relu,
+    LeakyRelu,
     Exp,
     LT,
     EQ,
@@ -124,6 +125,10 @@ export class Scalar {
 
     relu(): Scalar {
         return Scalar.apply(Relu, this);
+    }
+
+    leakyRelu(): Scalar {
+        return Scalar.apply(LeakyRelu, this);
     }
 
     chainRule(dOut: number): Iterable<GradPair> {

--- a/packages/tstorch/src/scalar_functions.ts
+++ b/packages/tstorch/src/scalar_functions.ts
@@ -111,6 +111,20 @@ export class Relu extends ScalarFunction {
     }
 }
 
+const LEAKY_SLOPE = 0.01;
+
+export class LeakyRelu extends ScalarFunction {
+    static forward(ctx: Context, a: number): number {
+        ctx.saveForBackward(a);
+        return a > 0 ? a : LEAKY_SLOPE * a;
+    }
+
+    static backward(ctx: Context, dOut: number): number[] {
+        const [a] = ctx.savedValues;
+        return [dOut * (a! > 0 ? 1 : LEAKY_SLOPE)];
+    }
+}
+
 export class Exp extends ScalarFunction {
     static forward(ctx: Context, a: number): number {
         const result = operators.exp(a);


### PR DESCRIPTION
Significant amount of changes:
- Optimize spiral dataset training
    - BCEWithLogitsLoss — symmetric gradients, no log(sigmoid) numerical path
    - He initialization — proper weight scale for ReLU-family activations
    - Zero bias init — prevents dead neurons at startup
    - LeakyReLU — ensures gradients always flow, neurons can revive
    - Adam optimizer — adaptive learning rates + momentum smooth out the noisy loss landscape
    - Multi-layer architecture — depth to represent the spiral boundary