### PR TITLE
toy subpath export in NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,40 @@
 {
   "name": "@mni-ml/framework",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mni-ml/framework",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "typescript": "^5.9.3"
+        "@webgpu/types": "^0.1.69",
+        "typescript": "^5.9.3",
+        "webgpu": "^0.4.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.18.0"
       },
       "optionalDependencies": {
-        "@mni-ml/framework-darwin-arm64": "0.3.0",
-        "@mni-ml/framework-darwin-x64": "0.3.0",
-        "@mni-ml/framework-linux-arm64-gnu": "0.3.0",
-        "@mni-ml/framework-linux-x64-gnu": "0.3.0",
-        "@mni-ml/framework-linux-x64-gnu-cuda": "0.3.0",
-        "@mni-ml/framework-win32-x64-msvc": "0.3.0"
+        "@mni-ml/framework-darwin-arm64": "0.3.1",
+        "@mni-ml/framework-darwin-arm64-webgpu": "0.3.1",
+        "@mni-ml/framework-darwin-x64": "0.3.1",
+        "@mni-ml/framework-darwin-x64-webgpu": "0.3.1",
+        "@mni-ml/framework-linux-arm64-gnu": "0.3.1",
+        "@mni-ml/framework-linux-x64-gnu": "0.3.1",
+        "@mni-ml/framework-linux-x64-gnu-cuda": "0.3.1",
+        "@mni-ml/framework-linux-x64-gnu-webgpu": "0.3.1",
+        "@mni-ml/framework-win32-x64-msvc": "0.3.1",
+        "@mni-ml/framework-win32-x64-msvc-cuda": "0.3.1",
+        "@mni-ml/framework-win32-x64-msvc-webgpu": "0.3.1"
       }
     },
     "node_modules/@mni-ml/framework-darwin-arm64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mni-ml/framework-darwin-arm64/-/framework-darwin-arm64-0.3.0.tgz",
-      "integrity": "sha512-5YPtWKO78ZnqhetmHNBSDdUP2/ZwkVyraIDyH9C7+ybGCSrlhnFfOgFfi8IsfiJVgM4QMgqedQXwkqszw8DyYw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-darwin-arm64/-/framework-darwin-arm64-0.3.1.tgz",
+      "integrity": "sha512-FdTk97GQEXwpyK4kC28ERDTb28LsRe99z48dd3gkmAi3fHsacT3W+xasbDOOHqZXygvmUNdRcSFOnFUDQLKw0g==",
       "cpu": [
         "arm64"
       ],
@@ -37,10 +44,10 @@
         "darwin"
       ]
     },
-    "node_modules/@mni-ml/framework-darwin-x64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mni-ml/framework-darwin-x64/-/framework-darwin-x64-0.3.0.tgz",
-      "integrity": "sha512-t70PS3mT+TonKyGyzPwQRGjp2fvzB12JEke/Z7nr639t+7stOOKjA1i0R2qKs2xHHRKX2NeGwVvX+6xtyS4JKQ==",
+    "node_modules/@mni-ml/framework-darwin-x64-webgpu": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-darwin-x64-webgpu/-/framework-darwin-x64-webgpu-0.3.1.tgz",
+      "integrity": "sha512-pAqCzdohURJYouNd7C3bA5Or6XjC1Z68zAyXJOruNW3FdwInNXIRD8sp5O15WAodwZuEIxouaQwG4HSAs7iQuw==",
       "cpu": [
         "x64"
       ],
@@ -51,9 +58,9 @@
       ]
     },
     "node_modules/@mni-ml/framework-linux-arm64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mni-ml/framework-linux-arm64-gnu/-/framework-linux-arm64-gnu-0.3.0.tgz",
-      "integrity": "sha512-MjEiKh0ks7dZHzlwxVB4G6rUeMAzBnRy/UH846tMK65s031NUrVW8DdO8CWBoED622kcYqECftAZ3d7kXwDQnA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-linux-arm64-gnu/-/framework-linux-arm64-gnu-0.3.1.tgz",
+      "integrity": "sha512-blhGI23BoOyek6wiNX4or4pcg893PtQPzN18ALnWnadfcEDaMKymT9Vy3+84rxB98+M1ClZhih6AjcoZp5ZdRw==",
       "cpu": [
         "arm64"
       ],
@@ -63,10 +70,10 @@
         "linux"
       ]
     },
-    "node_modules/@mni-ml/framework-linux-x64-gnu": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mni-ml/framework-linux-x64-gnu/-/framework-linux-x64-gnu-0.3.0.tgz",
-      "integrity": "sha512-FHYhTz5qxewxC3Q1QneHCHpq29JiHwgz5oi7cJixXDsAjcZYt35Cdrhl0dUAWfDnhu7p7nVn+964aIYkivcIig==",
+    "node_modules/@mni-ml/framework-linux-x64-gnu-cuda": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-linux-x64-gnu-cuda/-/framework-linux-x64-gnu-cuda-0.3.1.tgz",
+      "integrity": "sha512-yW1Nd5R7eqVPTeLEdXfJeg4e75guChSu2D/TckdW8Oje6oqnfhEf7JeGbRJ33jS75a+IaF83etAtBhPTrOA8AA==",
       "cpu": [
         "x64"
       ],
@@ -76,10 +83,10 @@
         "linux"
       ]
     },
-    "node_modules/@mni-ml/framework-linux-x64-gnu-cuda": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mni-ml/framework-linux-x64-gnu-cuda/-/framework-linux-x64-gnu-cuda-0.3.0.tgz",
-      "integrity": "sha512-ehJwI5qmAH4x+YnKQFPok8KLR4JYkSV0ohOWP+BXY7JiFhvhreijHSSwdyxJqMy+b5nbBdWUJ/eK6/CqZ7AQug==",
+    "node_modules/@mni-ml/framework-linux-x64-gnu-webgpu": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-linux-x64-gnu-webgpu/-/framework-linux-x64-gnu-webgpu-0.3.1.tgz",
+      "integrity": "sha512-RIFSgKVa63h2v4NPumSrQa8dROlvcVbuhXYA//vuxhKssocSQWHH3WeCMlA80X8k+LlzTeb/YDQI4d3aZWQEFQ==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +97,35 @@
       ]
     },
     "node_modules/@mni-ml/framework-win32-x64-msvc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mni-ml/framework-win32-x64-msvc/-/framework-win32-x64-msvc-0.3.0.tgz",
-      "integrity": "sha512-G9OmGZFlOjBAmCM8/Nn9Xgi6YHoSFUlkMmONPpW13dlP6QnO22YzayUZ01hYZgXn7HtPFCJNwPeI/AAJnzB5cA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-win32-x64-msvc/-/framework-win32-x64-msvc-0.3.1.tgz",
+      "integrity": "sha512-n5THgf3cJIdRld48ecAiAFAx21YCT9bo5zKNdNnkb5xHTTi9IF2SZduHZL3TKTKz52J+AFZsYoESqtWtRd9DgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@mni-ml/framework-win32-x64-msvc-cuda": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-win32-x64-msvc-cuda/-/framework-win32-x64-msvc-cuda-0.3.1.tgz",
+      "integrity": "sha512-Pb9jWoZo4ocTtYyMS7bfvcFiXNRuhnYGc6rY3nfyRy01sLPbMurS9uYys+cyIbaM7xQl3/SnttBY0RbEqK0ztg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@mni-ml/framework-win32-x64-msvc-webgpu": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mni-ml/framework-win32-x64-msvc-webgpu/-/framework-win32-x64-msvc-webgpu-0.3.1.tgz",
+      "integrity": "sha512-eztnCED54Y4fy0KioovtleqwwFq613x8Z/wAcLTjsvT8Xl+O2aL9jUfECtPbQeRS0obGBcmgfSwHMMs/KNPrcA==",
       "cpu": [
         "x64"
       ],
@@ -111,6 +144,38 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -132,6 +197,18 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webgpu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/webgpu/-/webgpu-0.4.0.tgz",
+      "integrity": "sha512-F5pimn3Aoi0zWjuRdiVs5TnrUwSzD2lESBohsIUsqyitWkGRQlXU2fhV6ycXlQTa1bvAf3sjqiUpBEpmSQ5ptA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webgpu/types": "^0.1.69",
+        "debug": "^4.4.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./toy": {
+      "types": "./dist/toy/index.d.ts",
+      "import": "./dist/toy/index.js"
     }
   },
   "files": [
@@ -50,10 +54,12 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.9.3"
+    "@webgpu/types": "^0.1.69",
+    "typescript": "^5.9.3",
+    "webgpu": "^0.4.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.toy.json",
     "build:native": "cd src/native && cargo build --release --features cpu && cp target/release/libmni_framework_native.dylib mni-framework-native.darwin-arm64.node",
     "build:native:cuda": "cd src/native && cargo build --release --no-default-features --features cuda && cp target/release/libmni_framework_native.so mni-framework-native.linux-x64-gnu.node",
     "build:native:webgpu": "cd src/native && cargo build --release --no-default-features --features webgpu && cp target/release/libmni_framework_native.dylib mni-framework-native.darwin-arm64.node",

--- a/tsconfig.toy.json
+++ b/tsconfig.toy.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "composite": false,
+        "rootDir": "./toy",
+        "outDir": "./dist/toy",
+        "types": ["node", "@webgpu/types"]
+    },
+    "include": ["toy/**/*.ts"],
+    "exclude": ["**/*.test.ts", "dist", "node_modules"]
+}


### PR DESCRIPTION
Builds toy/ to dist/toy/ via a separate tsconfig and adds the ./toy subpath export so the browser demo can do `import { Tensor } from '@mni-ml/framework/toy'` without loading the native addon.

`@webgpu/types` lands as a devDep so tsc picks up GPU* ambient types.

Verified: `npm run build` clean, `dist/toy/index.js` present, import resolves.